### PR TITLE
Changes to brute_force_slots

### DIFF
--- a/core/simulate.py
+++ b/core/simulate.py
@@ -170,7 +170,8 @@ def brute_force_slots(classname, conf, output, team_dps, duration):
         His_Clever_Brother,
         The_Lurker_in_the_Woods,
         Stellar_Show,
-        Candy_Couriers
+        Candy_Couriers,
+        Twinfold_Bonds
     ]
     adv_ele = adv.slots.c.ele.lower()
     results = []

--- a/core/simulate.py
+++ b/core/simulate.py
@@ -131,10 +131,14 @@ def test(classname, conf={}, duration=180, verbose=0, mass=None, output=None, te
     return run_results
 
 def brute_force_slots(classname, conf, output, team_dps, duration):
-    from app.app import is_amulet, is_dragon
+    #from app.app import is_amulet, is_dragon
     import inspect
     import io
     import slot.d
+    def is_dragon(obj):
+        return (inspect.isclass(obj) and issubclass(obj, slot.d.DragonBase)
+                and obj.__module__ != 'slot.d'
+                and obj.__module__ != 'slot')
     adv = classname(conf)
     exclude = ('Dear_Diary_RO_30', 'Dear_Diary_RO_60', 'Dear_Diary_RO_90')
     # amulets = list(set(c for _, c in inspect.getmembers(slot.a, is_amulet) if c.__qualname__ not in exclude))


### PR DESCRIPTION
Removed `import from app.app` and copied definition of `app.app.is_dragon(obj)` in `brute_force_slots` in order to prevent a `ModuleNotFoundError` when running `sim(.bat) <adventurer> -3` without flask installed. Also added Twinfold Bonds to the list of Wyrmprints tested by `brute_force_slots`.