### PR TITLE
light coab edits, fire print edits, lathna edits

### DIFF
--- a/adv/amane.py
+++ b/adv/amane.py
@@ -14,7 +14,7 @@ class Amane(Adv):
         `s1
         `s3, x=5
         """
-    coab = ['Blade','Raemond','Peony']
+    coab = ['Blade','Halloween_Elisanne','Peony']
 
 
 if __name__ == '__main__':

--- a/adv/annelie.py
+++ b/adv/annelie.py
@@ -22,7 +22,7 @@ class Annelie(Adv):
         `s3
         `fs, seq=5 
         """
-    coab = ['Lucretia','Dagger','Peony']
+    coab = ['Halloween_Elisanne','Dagger','Peony']
 
     def prerun(self):
         self.stance = 0

--- a/adv/b_zardin.py
+++ b/adv/b_zardin.py
@@ -14,7 +14,7 @@ class Beautician_Zardin(Adv):
         `s1
         `s3
         """
-    coab = ['Wand','Dagger','Peony']
+    coab = ['Halloween_Elisanne','Dagger','Peony']
 
     def s1_proc(self, e):
         self.energy.add(1)

--- a/adv/chitose.py
+++ b/adv/chitose.py
@@ -17,7 +17,7 @@ class Chitose(Adv):
         `s1
         `s3, seq=5
         """
-    coab = ['Tobias','Blade','Bow']
+    coab = ['Tobias','Peony','Bow']
 
     def init(self):
         self.buff_class = Teambuff if self.condition('buff all team') else Selfbuff

--- a/adv/curran.py
+++ b/adv/curran.py
@@ -14,9 +14,7 @@ class Curran(Adv):
     conf['slots.d'] = Fatalis()
     conf['slots.poison.d'] = Shinobi()
     conf['acl'] = """
-        if self.slots.d.name != 'Fatalis'
         `dragon.act("c3 s end")
-        end
         `s3, not self.s3_buff
         `s1
         `s2

--- a/adv/durant.py
+++ b/adv/durant.py
@@ -17,9 +17,7 @@ class Durant(Adv):
     conf['slots.poison.d'] = Epimetheus()
     
     conf['acl'] = """
-        if self.slots.d.name != 'Fatalis'
         `dragon, s=1
-        end
         `s3, not self.s3_buff
         `s1
         `s2, x=5

--- a/adv/elias.py
+++ b/adv/elias.py
@@ -15,7 +15,7 @@ class Elias(Adv):
         `s2, fsc
         `fs, x=4
         """
-    coab = ['Blade','Lucretia','Peony']
+    coab = ['Blade','Halloween_Elisanne','Peony']
 
     def s2_proc(self, e):
         self.energy.add(1, team=True)

--- a/adv/erik.py
+++ b/adv/erik.py
@@ -10,9 +10,7 @@ class Erik(Adv):
     conf['slots.d'] = Fatalis()
     conf['slots.poison.d'] = Shinobi()
     conf['acl'] = """
-        if self.slots.d.name != 'Fatalis'
         `dragon.act("c3 s end")
-        end
         `s3, not self.s3_buff
         `s1
         `s2, fsc

--- a/adv/fritz.py
+++ b/adv/fritz.py
@@ -11,7 +11,7 @@ class Fritz(Adv):
         `s3
         `fs, x=5
         """
-    coab = ['Blade','Wand','Peony']
+    coab = ['Blade','Halloween_Elisanne','Peony']
 
     def prerun(self):
         self.stance = 0

--- a/adv/h_edward.py
+++ b/adv/h_edward.py
@@ -13,7 +13,7 @@ class Halloween_Edward(Adv):
         `s2, x=5
         `s3
         """
-    coab = ['Wand','Dagger','Peony']
+    coab = ['Halloween_Elisanne','Dagger','Peony']
 
 if __name__ == '__main__':
     from core.simulate import test_with_argv

--- a/adv/h_elisanne.py
+++ b/adv/h_elisanne.py
@@ -14,7 +14,7 @@ class Halloween_Elisanne(Adv):
         `s3
         `fs, x=5
         """
-    coab = ['Blade','Dagger','Wand']
+    coab = ['Blade','Dagger','Peony']
 
     def prerun(self):
         self.stance = 0

--- a/adv/hanabusa.py
+++ b/adv/hanabusa.py
@@ -11,7 +11,7 @@ class Hanabusa(Adv):
         `s2
         `s3
         """
-    coab = ['Wand','Dagger','Peony']
+    coab = ['Halloween_Elisanne','Dagger','Peony']
 
     def prerun(self):
         self.stance = 0

--- a/adv/hawk.py
+++ b/adv/hawk.py
@@ -8,6 +8,7 @@ def module():
 class Hawk(Adv):
     a1 = [('edge_stun', 50), ('edge_poison', 50)]
     a3 = [('k_stun',0.4), ('k_poison',0.3)]
+    
     conf = {}
     conf['slots.a'] = Resounding_Rendition()+The_Fires_of_Hate()
     conf['acl'] = """
@@ -15,7 +16,7 @@ class Hawk(Adv):
         # s2; s3; fs; s1, fsc; fs; s1, fsc; s1, cancel; s2, cancel
         # end
         `s3, not self.s3_buff
-        `dragon.act('c3 s end'), s
+        `dragon.act('c3 s end'), s and self.duration >= 120
         `s2, self.fs_alt.uses=0 or (self.s2_mode=1)
         `fs, (s1.check() and self.fs_alt.uses>1) or (x=4 and self.s2_mode=0 and self.fs_alt.uses>0)
         `s1, fsc or s=1
@@ -24,10 +25,6 @@ class Hawk(Adv):
     coab = ['Blade','Dragonyule_Xainfried','Sylas']
     conf['afflict_res.stun'] = 80
     conf['afflict_res.poison'] = 0
-    
-    def d_slots(self):
-        if self.duration <= 60:
-            self.conf['slots.a'] = The_Chocolatiers()+The_Fires_of_Hate()
     
     def fs_proc_alt(self, e):
         self.afflics.stun('fs', 110)

--- a/adv/irfan.py
+++ b/adv/irfan.py
@@ -12,7 +12,7 @@ class Irfan(Adv):
         `s3
         `fs, seq=5
         """
-    coab = ['Blade','Wand','Peony']
+    coab = ['Blade','Halloween_Elisanne','Peony']
 
 
 if __name__ == '__main__':

--- a/adv/jurota.py
+++ b/adv/jurota.py
@@ -8,7 +8,7 @@ class Jurota(Adv):
     a1 = ('bk',0.2)
 
     conf = {}
-    conf['slot.d'] = Leviathan()
+    conf['slots.d'] = Leviathan()
     conf['acl'] = """
         `dragon
         `s1

--- a/adv/kleimann.py
+++ b/adv/kleimann.py
@@ -18,7 +18,11 @@ class Kleimann(Adv):
         `s2
         `fs, self.madness_status<5 and self.madness>0
         """
-    coab = ['Ieyasu','Bow','Dagger']
+    coab = ['Ieyasu','Gala_Alex','Dagger']
+
+    def d_coabs(self):
+        if self.duration <= 60:
+            self.coab = ['Ieyasu','Gala_Alex','Bow']
 
     def madness_autocharge(self, t):
         for s in (self.s1, self.s2, self.s3):

--- a/adv/lathna.py
+++ b/adv/lathna.py
@@ -10,15 +10,33 @@ class Lathna(Adv):
     a3 = ('dt', 0.25)
     
     conf = {}
-    conf['slots.a'] = Resounding_Rendition()+An_Ancient_Oath()
+    conf['slots.a'] = Resounding_Rendition()+The_Red_Impulse()
     conf['slots.d'] = Chthonius()
+    conf['slots.poison.d'] = Shinobi()
     conf['acl'] = """
         `dragon
         `s3, not self.s3_buff
         `s1a
         `s2, x=5
         """
-    coab = ['Ieyasu','Gala_Alex','Cleo']
+    coab = ['Ieyasu','Wand','Cleo']
+
+    def d_coabs(self):
+        if self.duration <= 120 and self.duration > 60:
+            self.coab = ['Ieyasu','Yaten','Cleo']
+        if self.duration <= 60:
+            self.coab = ['Ieyasu','Gala_Alex','Cleo']
+        if 'sim_afflict' in self.conf and self.conf.sim_afflict.efficiency > 0:
+            if self.duration <= 180 and self.duration > 60:
+                self.coab = ['Ieyasu','Wand','Cleo']
+            if self.duration <= 60:
+                self.coab = ['Ieyasu','Yaten','Cleo']
+    
+    def d_slots(self):
+        if self.duration <= 120:
+            self.conf['slots.a'] = Resounding_Rendition()+An_Ancient_Oath()
+        if self.duration <= 60:
+            self.conf['slots.poison.d'] = Chthonius()
     
     conf['dragonform'] = {
         'act': 'c3 s c3 c3 c2 c2 c2',
@@ -41,10 +59,6 @@ class Lathna(Adv):
 
         'dodge.startup': 41 / 60.0, # dodge frames
     }
-
-    def d_slots(self):
-        if self.duration <= 120:
-            self.conf['slots.poison.a'] = An_Ancient_Oath()+The_Fires_of_Hate()
 
     def ds_proc(self):
         dmg = self.dmg_make('ds', 3.64, 's')

--- a/adv/lathna.py
+++ b/adv/lathna.py
@@ -19,7 +19,7 @@ class Lathna(Adv):
         `s1a
         `s2, x=5
         """
-    coab = ['Ieyasu','Euden','Cleo']
+    coab = ['Ieyasu','Audric','Cleo']
 
     def d_coabs(self):
         if self.duration <= 120 and self.duration > 60:

--- a/adv/lathna.py
+++ b/adv/lathna.py
@@ -10,7 +10,7 @@ class Lathna(Adv):
     a3 = ('dt', 0.25)
     
     conf = {}
-    conf['slots.a'] = Resounding_Rendition()+The_Red_Impulse()
+    conf['slots.a'] = Resounding_Rendition()+An_Ancient_Oath()
     conf['slots.d'] = Chthonius()
     conf['slots.poison.d'] = Shinobi()
     conf['acl'] = """
@@ -19,7 +19,7 @@ class Lathna(Adv):
         `s1a
         `s2, x=5
         """
-    coab = ['Ieyasu','Wand','Cleo']
+    coab = ['Ieyasu','Euden','Cleo']
 
     def d_coabs(self):
         if self.duration <= 120 and self.duration > 60:
@@ -33,8 +33,6 @@ class Lathna(Adv):
                 self.coab = ['Ieyasu','Yaten','Cleo']
     
     def d_slots(self):
-        if self.duration <= 120:
-            self.conf['slots.a'] = Resounding_Rendition()+An_Ancient_Oath()
         if self.duration <= 60:
             self.conf['slots.poison.d'] = Chthonius()
     

--- a/adv/laxi.py
+++ b/adv/laxi.py
@@ -9,7 +9,7 @@ class Laxi(Adv):
     comment = "a1 proc at 0s"
     
     conf = {}
-    conf['slots.burn.a'] = Primal_Crisis()+Elegant_Escort()
+    conf['slots.a'] = Primal_Crisis()+The_Wyrmclan_Duo()
     conf['slots.d'] = Gala_Mars()
     conf['acl'] = """
         `dragon, s

--- a/adv/luca.py
+++ b/adv/luca.py
@@ -8,7 +8,7 @@ class Luca(Adv):
     a1 = ('a',0.13,'hp100')
 
     conf = {}
-    conf['slots.paralysis.a'] = Resounding_Rendition()+Spirit_of_the_Season()
+    conf['slots.a'] = Resounding_Rendition()+Spirit_of_the_Season()
     conf['acl'] = """
         `dragon
         `s1
@@ -16,7 +16,7 @@ class Luca(Adv):
         `s3
         `fs, seq=4
         """
-    coab = ['Blade','Sharena','Peony']
+    coab = ['Blade','Halloween_Elisanne','Peony']
     conf['afflict_res.paralysis'] = 0
 
     def s1_proc(self, e):

--- a/adv/malora.py
+++ b/adv/malora.py
@@ -8,7 +8,6 @@ class Malora(Adv):
     a1 = ('bk',0.2)
     
     conf = {}
-    conf['slots.a'] = RR()+Breakfast_at_Valerios()
     conf['acl'] = """
         `dragon
         `s1
@@ -16,7 +15,7 @@ class Malora(Adv):
         `s3, cancel
         `fs, x=4
         """
-    coab = ['Blade','Wand','Peony']
+    coab = ['Blade','Halloween_Elisanne','Peony']
 
 
 if __name__ == '__main__':

--- a/adv/marty.py
+++ b/adv/marty.py
@@ -9,7 +9,8 @@ class Marty(Adv):
     a1 = ('sp',0.05)
 
     conf = {}
-    conf['slots.a'] = Resounding_Rendition()+Breakfast_at_Valerios()
+    conf['slots.a'] = The_Wyrmclan_Duo()+Primal_Crisis()
+    conf['slots.burn.a'] = Resounding_Rendition()+Elegant_Escort()
     conf['acl'] = """
         `dragon, s
         `s3, fsc and not self.s3_buff

--- a/adv/mikoto.py
+++ b/adv/mikoto.py
@@ -10,7 +10,7 @@ class Mikoto(Adv):
     a3 = ('cc',0.08)
     
     conf = {}
-    conf['slots.burn.a'] = Primal_Crisis()+Elegant_Escort()
+    conf['slots.a'] = Primal_Crisis()+The_Wyrmclan_Duo()
     conf['acl'] = """
         `dragon, s=2
         `s3, x=5 and not self.s3_buff

--- a/adv/nobunaga.py
+++ b/adv/nobunaga.py
@@ -9,8 +9,10 @@ class Nobunaga(Adv):
     comment = 'use s2 instead of fs to dispel when possible'
 
     a1 = ('a',0.2,'hit15')
+
     conf = {}
-    conf['slots.a'] = Resounding_Rendition()+Breakfast_at_Valerios()
+    conf['slots.a'] = The_Wyrmclan_Duo()+Primal_Crisis()
+    conf['slots.burn.a'] = Resounding_Rendition()+Elegant_Escort()
     conf['acl'] = """
         `dragon, s=2
         `s3, not self.s3_buff

--- a/adv/rena.py
+++ b/adv/rena.py
@@ -16,8 +16,12 @@ class Rena(Adv):
         `s2, s=1
         `fs, x=5 and (s1.charged=1500 or s1.charged=3200)
     """
-    coab = ['Wand', 'Dagger', 'Marth']    
+    coab = ['Wand', 'Joe', 'Marth']    
     conf['afflict_res.burn'] = 0
+
+    def d_coabs(self):
+        if self.duration <= 120:
+            self.coab = ['Blade','Wand','Serena']
 
     def prerun(self):
         self.stance = 0

--- a/adv/xuanzang.py
+++ b/adv/xuanzang.py
@@ -8,6 +8,7 @@ class Xuan_Zang(Adv):
     a3 = ('cc',0.06,'hp70')
     
     conf = {}
+    conf['slots.a'] = The_Wyrmclan_Duo()+Primal_Crisis()
     conf['slots.burn.a'] = Resounding_Rendition()+Elegant_Escort()
     conf['acl'] = """
         `dragon, s=2


### PR DESCRIPTION
Light - Helly beats wand in a all the cases that were using wand. Technically she can slightly outperform blade in sim but I decided against changing that.
Fire - just some very minor print optimization with TWD+PC being better than RR+BaV by a negligible amount I noticed
Issue #58 - If you can find a cleaner way to do lathna that would be ideal, I was lazy so I just used if statements :worrydumb:
Since `dragon no longer has any effect with Fatalis  if statements were removed from curran/erik/durant acl
For hawk it seemed that RR+FoH now outperforms choco+FoH in sim as long as you don't dragon with RR+FoH in 60s thus acl edit to only dragon in 120s+ and removed the 60s print change