### PR TITLE
Make Extra Energy shared skill-friendly

### DIFF
--- a/ability/__init__.py
+++ b/ability/__init__.py
@@ -683,3 +683,16 @@ class Crisis_Att_Spd(Ability):
         adv.Event('hp').listener(l_cas_buff)
 
 ability_dict['crisisattspd'] = Crisis_Att_Spd
+
+class Energy_Extra(Ability):
+    def __init__(self, name, value):
+        self.value = value
+        super().__init__(name)
+
+    def oninit(self, adv, afrom=None):
+        def l_energy(e):
+            adv.energy.add_extra(self.value) #means
+
+        adv.Event('energy').listener(l_energy)
+
+ability_dict['eextra'] = Energy_Extra

--- a/adv/natalie.py
+++ b/adv/natalie.py
@@ -6,6 +6,7 @@ def module():
     return Natalie
 
 class Natalie(Adv):
+    a1 = ('eextra', 0.8)
     a3 = ('crisisattspd', 3)
 
     conf = {}
@@ -28,7 +29,7 @@ class Natalie(Adv):
         with CrisisModifier(e.name, 1, self.hp):
             self.dmg_make(e.name, 10.62)
 
-        self.energy.add(1.8)
+        self.energy.add(1)
         # self.energy.add(1)
         # if random.random() < 0.8:
         #     self.energy.add(1)

--- a/adv/summer_luca.py
+++ b/adv/summer_luca.py
@@ -6,6 +6,7 @@ def module():
 
 class Summer_Luca(Adv):
     a1 = ('a',0.1,'hp70')
+    a3 = ('eextra', 0.4)
 
     conf = {}
     conf['slots.a'] = RR()+Breakfast_at_Valerios()
@@ -21,7 +22,7 @@ class Summer_Luca(Adv):
 
     def s2_proc(self, e):
         Spdbuff(e.name,0.2,10).on()
-        self.energy.add(1.4) # means
+        self.energy.add(1)
 
 
 if __name__ == '__main__':

--- a/module/tension.py
+++ b/module/tension.py
@@ -33,6 +33,16 @@ class Tension:
         self.event.stack = self.stack
         self.event.on()
 
+    def add_extra(self, n, team=False):
+        if team:
+            log('{}_extra'.format(self.name), 'team', n)
+        if self.stack == self.MAX_STACK:
+            return
+        self.stack += n
+        if self.stack >= self.MAX_STACK:
+            self.stack = self.MAX_STACK
+        log('{}_extra'.format(self.name), '+{}'.format(n), 'stack <{}>'.format(self.stack))
+
     def check(self, scope):
         if self.stack >= self.MAX_STACK:
             if self.current_scope is None and scope in self.scope and scope in self.damage_sources:


### PR DESCRIPTION
Changed Extra Energy to work as an ability instead of hardcoding means into the skill proc methods. This fixes two problems it had when simulating with shared skills:
* if Natalie or Summer Luca borrowed a skill that granted them energy, that shared skill would not be impacted by their Extra Energy ability
* if Pipple or Yaten borrowed Natalie's s1 or Summer Luca's s2, the sim would complain that "tuple indices must be integers or slices, not floats" due to the implementation of `epassive` abilities using the energy stacks as indices for the buff value tuples.