### PR TITLE
Rodrigo ACL optimization

### DIFF
--- a/adv/rodrigo.py
+++ b/adv/rodrigo.py
@@ -9,10 +9,10 @@ class Rodrigo(Adv):
     conf = {}
     conf['slots.a'] = The_Shining_Overlord()+The_Fires_of_Hate()
     conf['acl'] = """
-        `dragon.act("c3 s end")
+        `dragon.act("c3 s end"),fsc
         `s3, not self.s3_buff
         `s4
-        `s1
+        `s1,cancel and self.s3_buff
         `s2, fsc
         `fs, x=3
         """


### PR DESCRIPTION
ACL optimization to get more hits in before using dragon or s1. also uses s1 only after agito buff is up. ~2000 DPS increase in both none and 100% affliction modes