### PR TITLE
Berserker update

### DIFF
--- a/adv/berserker.py
+++ b/adv/berserker.py
@@ -8,16 +8,16 @@ def module():
 class Berserker(Adv):
     a3 = ('lo',0.3)
     conf = {}
-    conf['slots.a'] = The_Shining_Overlord()+The_Lurker_in_the_Woods()
-    conf['slots.poison.a'] = The_Shining_Overlord()+The_Plaguebringer()
+    conf['slots.a'] = The_Shining_Overlord()+Primal_Crisis()
+    conf['slots.poison.a'] = The_Shining_Overlord()+Primal_Crisis()
     conf['acl'] = """
-        `dragon
-        `s3, not self.s3_buff
-        `s1
+        `dragon.act('c3 s end'),fsc
+        `s3, not self.s3_buff and fsc
         `s4
+        `s1,fsc
         `fs, x=3
         """
-    coab = ['Berserker','Ieyasu','Wand','Dagger2']
+    coab = ['Berserker','Ieyasu','Wand','Curran']
     share = ['Curran']
 
     def s1_proc(self, e):


### PR DESCRIPTION
Build was outdated and based on Fatalis. New build focuses on using Curran's SS as much as possible, while everything else is on fsc. Dagger coab changed to Curran.

2nd print in both in and out of 100% poison is changed to primal crisis, as it provides the most DPS. If practicality is a factor, we can revert the prints to the lurker in the woods/the plaguebringer. 