### PR TITLE
Sazanka update

### DIFF
--- a/adv/sazanka.py
+++ b/adv/sazanka.py
@@ -10,16 +10,14 @@ class Sazanka(Adv):
     a3 = ('k_sleep', 0.20)
 
     conf = {}
-    conf['slots.a'] = KFM()+Crystalian_Envoy()
+    conf['slots.a'] = Summer_Paladyns()+Primal_Crisis()
     conf['acl'] = """
-        `dragon.act("c3 s end")
+        `dragon.act("c3 s end"),s1.charged=s1.sp
         `s3, not self.s3_buff
         `s4
         `s1
-        `s2, fsc
-        `fs, seq=5
     """
-    coab = ['Blade', 'Wand', 'Dagger']
+    coab = ['Ieyasu', 'Wand', 'Bow']
     conf['afflict_res.sleep'] = 80
     share = ['Curran']
 


### PR DESCRIPTION
KFM -> summer paladyns
crystalian envoy -> primal crisis
removed S2 and FS from the acl
shapeshift when s1 is ready (no UI lag on shapeshift end so s1 is used instantly)
blade coab -> ieyasu
dagger coab -> bow