### PR TITLE
Dragondrive end doesn't refill Cat Sith's buff stacks

### DIFF
--- a/slot/d/shadow.py
+++ b/slot/d/shadow.py
@@ -343,7 +343,8 @@ class Gala_Cat_Sith(DragonBase):
             self.trickery_buff.on()
 
     def shift_end_trickery(self, e):
-        self.add_trickery(8)
+        if not self.adv.dragonform.is_dragondrive:
+            self.add_trickery(8)
 						
 class Unreleased_ShadowCritDamage(DragonBase):
     ele = 'shadow'


### PR DESCRIPTION
Fixes damage calculation for shadow adventurers with dragondrive that have Cat Sith equipped