### PR TITLE
coabilities mistake + laranoa

### DIFF
--- a/adv/botan.py
+++ b/adv/botan.py
@@ -17,7 +17,7 @@ class Botan(Adv):
         `s1
         `fs,x=5
     """
-    coab = ['Blade','Wand','Dagger  ']
+    coab = ['Blade','Wand','Dagger']
     share = ['Curran']
 
     def init(self):

--- a/adv/laranoa.py
+++ b/adv/laranoa.py
@@ -15,10 +15,11 @@ class Laranoa(Adv):
     conf['slots.frostbite.a'] = Resounding_Rendition()+His_Clever_Brother()
     conf['slots.d'] = Gaibhne_and_Creidhne()
     conf['acl'] = """
+        `dragon.act('c3 s end'),s
         `s3
+        `s2
         `s4
         `s1
-        `s2, fsc
         `fs, seq=4
     """
     coab = ['Renee', 'Xander', 'Summer_Estelle']

--- a/adv/mikoto.py
+++ b/adv/mikoto.py
@@ -22,7 +22,7 @@ class Mikoto(Adv):
         `s1, cancel
         `s2, x=5
         """
-    coab = ['Haloween_Mym', 'Dagger2', 'Marth']
+    coab = ['Halloween_Mym', 'Dagger2', 'Marth']
     share = ['Kleimann']
 
     def prerun(self):


### PR DESCRIPTION
alt tabbing between windows caused some accidental spaces in some coability string names

also adding dragon to laranoa. i dont know why or how that was removed? either way, it's fixed now.