### PR TITLE
Fs_alt Class expansion 

### DIFF
--- a/adv/ku_hai.py
+++ b/adv/ku_hai.py
@@ -32,7 +32,6 @@ class Ku_Hai(Adv):
 
     def prerun(self):
         self.fshit = 2
-        self.alttimer = Timer(self.altend)
         conf_fs_alt = {
             'fs.dmg':0.83*2,
             'fs.sp' :330,
@@ -48,14 +47,15 @@ class Ku_Hai(Adv):
         if self.condition('big hitbox'):
             conf_fs_alt['fs.dmg'] += 0.83
             conf_fs_alt['fs.hit'] += 1
-        self.fs_alt = Fs_alt(self, Conf(conf_fs_alt))
-
-    def altend(self,t):
-        self.fs_alt.off()
+        self.fs_alt = Fs_alt(self, conf_fs_alt)
+        self.apsaras_formation_buff = EffectBuff(
+            'apsaras_formation', 10, 
+            lambda: self.fs_alt.on(-1), 
+            lambda: self.fs_alt.off()
+        )
 
     def s2_proc(self, e):
-        self.fs_alt.on(-1)
-        self.alttimer.on(10)
+        self.apsaras_formation_buff.on()
 
 if __name__ == '__main__':
     from core.simulate import test_with_argv

--- a/core/advbase.py
+++ b/core/advbase.py
@@ -823,11 +823,11 @@ class Fs_group(object):
     def __init__(self, name, conf, act=None):
         self.actions = {}
         self.conf = conf
-        fsconf = conf.fs
+        fsconf = conf[name]
         xnfsconf = [fsconf, fsconf, fsconf, fsconf, fsconf, fsconf]
 
         for i in range(5):
-            xnfs = 'x%dfs' % (i + 1)
+            xnfs = f'x{(i + 1)}{name}'
             if xnfs in self.conf:
                 xnfsconf[i] += self.conf[xnfs]
 
@@ -860,7 +860,7 @@ class FS_MH(Action):
         self.cancel_by = ['s','dodge']
 
     def act(self, action):
-        self.act_event.name = 'fs'
+        self.act_event.name = self.name
         self.act_event.idx = self.idx
         self.act_event()
 
@@ -1970,21 +1970,21 @@ class Adv(object):
         return count
 
     def l_melee_fs(self, e):
-        log('cast', 'fs')
-        dmg_coef = self.conf.fs.dmg
+        log('cast', e.name)
+        dmg_coef = self.conf['%s.dmg' % e.name]
         self.fs_before(e)
         self.update_hits('fs')
         self.dmg_make('fs', dmg_coef)
         self.fs_proc(e)
         self.think_pin('fs')
-        self.charge('fs', self.conf.fs.sp)
+        self.charge(e.name, self.conf[e.name].sp)
 
     def l_range_fs(self, e):
-        log('cast', 'fs')
+        log('cast', e.name)
         self.fs_before(e)
         self.update_hits('fs')
-        dmg_coef = self.conf['fs.dmg']
-        sp_gain = self.conf['fs.sp']
+        dmg_coef = self.conf['%s.dmg' % e.name]
+        sp_gain = self.conf['%s.sp' % e.name]
         missile_timer = Timer(self.cb_missile, self.conf['missile_iv']['fs'])
         missile_timer.dname = 'fs'
         # missile_timer.dname = 'fs_missile'

--- a/core/config.py
+++ b/core/config.py
@@ -305,6 +305,12 @@ class Conf(lobject):
             Conf.update(self, a)
         elif type(a) == dict:
             Conf.update(self, a)
+    
+    def __len__(self):
+        return len(self.__dict__)
+    
+    def items(self):
+        return self.__dict__.items()
 
 
 # all method in conf will be sync funtion, so use [function] to set a config to function

--- a/module/x_alt.py
+++ b/module/x_alt.py
@@ -3,27 +3,30 @@ from core.timeline import Listener, Timer, now
 from core.log import log
 from core.config import Conf
 from core.dragonform import DragonForm
+import re
 
 class Fs_alt:
     def __init__(self, adv, conf, fs_proc=None):
+        # TODO add l_fs_alt to better handle before and after when needed; maybe fsnf 
+        self.patterns = ["^a_fs(?!f).*", "^conf$", "^fs.*proc$"]
         self.adv = adv
-        self.a_fs_og = adv.a_fs
-        self.conf_og = adv.conf
-        self.fs_proc_og = adv.fs_proc
+        # self.a_fs_og = adv.a_fs
+        # self.conf_og = adv.conf
+        # self.fs_proc_og = adv.fs_proc
         self.conf_alt = adv.conf + Conf(conf)
-        self.a_fs_alt = Fs_group('fs', self.conf_alt)
-        self.fs_proc_alt = fs_proc
+        self.fs_proc_alt_temp = fs_proc
         self.uses = 0
         self.has_fsf = False
+        self.do_config(self.conf_alt)
         if 'fsf' in conf:
             self.a_fsf_og = adv.a_fsf
             self.a_fsf_alt = Fs('fsf', conf.fsf)
             self.a_fsf_alt.act_event = Event('none')
             self.has_fsf = True
 
-    def fs_proc(self, e):
-        if callable(self.fs_proc_alt):
-            self.fs_proc_alt(e)
+    def fs_proc_alt(self, e):
+        if callable(self.fs_proc_alt_temp):
+            self.fs_proc_alt_temp(e)
         if self.uses != -1:
             self.uses -= 1
             if self.uses == 0:
@@ -32,24 +35,59 @@ class Fs_alt:
     def on(self, uses = 1):
         log('debug', 'fs_alt on', uses)
         self.uses = uses
-        self.adv.a_fs = self.a_fs_alt
-        self.adv.conf = self.conf_alt
-        self.adv.fs_proc = self.fs_proc
+        # self.adv.a_fs = self.a_fs_alt
+        # self.adv.conf = self.conf_alt
+        # self.adv.fs_proc = self.fs_proc
+        for pattern in self.patterns:
+            self._replace(pattern)
         if self.has_fsf:
             self.adv.fsf = self.a_fsf_alt
 
     def off(self):
         log('debug', 'fs_alt off', 0)
         self.uses = 0
-        self.adv.a_fs = self.a_fs_og
-        self.adv.conf = self.conf_og
-        self.adv.fs_proc = self.fs_proc_og
+        # self.adv.a_fs = self.a_fs_og
+        # self.adv.conf = self.conf_og
+        # self.adv.fs_proc = self.fs_proc_og
+        for pattern in self.patterns:
+            self._restore(pattern)
         if self.has_fsf:
             self.adv.fsf = self.a_fsf_og
 
     def get(self):
         return self.uses
 
+    def do_config(self, conf):
+        r = re.compile("^f.*(?<!f)$")
+        fsns = list(filter(r.match, [n for n, c in conf.items()]))
+        for fsn in fsns: 
+            self._set_attr_f(fsn, conf)
+        if len(fsns) > 1:
+            self.a_fs_alt = lambda before: None
+        for pattern in self.patterns:
+            self._back_up(pattern)
+
+    def _back_up(self, pattern):
+        self._copy_attr(pattern, self, self.adv, "_og", "")
+
+    def _replace(self, pattern):
+        self._copy_attr(pattern, self.adv, self, "", "_alt")
+
+    def _restore(self, pattern):
+        self._copy_attr(pattern, self.adv, self, "", "_og")
+    
+    def _copy_attr(self, pattern, dest, orig, d_sfx, o_sfx):
+        r = re.compile(pattern)
+        attrs = list(filter(r.match, dir(self.adv)))
+        for attr in attrs:
+            setattr(dest, f'{attr}{d_sfx}', getattr(orig, f'{attr}{o_sfx}'))
+
+    def _set_attr_f(self, n, conf):
+            if not hasattr(self.adv, n):
+                setattr(self.adv, f'a_{n}', lambda before: None)
+                setattr(self.adv, n, lambda:getattr(self.adv, f'a_{n}')(self.adv.action.getdoing().name))
+            setattr(self, f'a_{n}_alt', Fs_group(n, conf))
+            
 class X_alt:
     def __init__(self, adv, name, conf, x_proc=None, no_fs=False, no_dodge=False):
         self.conf = Conf(conf)


### PR DESCRIPTION
Expanded the Fs_alt class to better handle multilevel fs alt triggered by the EffectBuff. 
Backward compatibility has been tested against all units that used Fs_alt before.

Albert's file was updated using the new functionality as an example:
- Simpler set up.
- He can now use his standard fs properly when not electrified, which will be switched off automatically when he becomes electrified.
- His fs alt duration is now tied to the electrified buff and can be affected by buff time ability now.

Ku Hai(Husbando)'s file was modified using the new EffectBuff too. 