### PR TITLE
Fix Gun bonuses & Ilia Bug Report

### DIFF
--- a/core/slots.py
+++ b/core/slots.py
@@ -88,7 +88,7 @@ class CharaBase(SlotBase):
         "lance": 0.05,
         "staff": 0.05,
         "axe": 0.05,
-        "gun": -0.1,  # opera (0.05) + fount (0.05) - diff in weap (0.225 - 0.205 = 0.2)
+        "gun": 0.075,  # opera (0.05) + fount (0.05) - diff in weap (0.225 - 0.200 = 0.025)
     }
     FAC_WEAPON_HP = FAC_WEAPON_ATT.copy()
 


### PR DESCRIPTION
Also Ilia is bugged. Her affliction build goes back to regular dagger coab instead of keeping Fritz / Mitsuhide every time i change it, even though DPS clearly improves. Even the icon remains that of regular dagger instead of changing.